### PR TITLE
Fix anchor offsets for sticky header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,6 @@ html {
   scroll-behavior: smooth;
 }
 
-/* section[id] {
+section[id] {
   scroll-margin-top: 112px;
-} */
+}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -20,7 +20,10 @@ export default function About() {
   ];
 
   return (
-    <section id="about" className="scroll-mt-28 w-[1440px] h-[600px] relative overflow-hidden">
+    <section
+      id="about"
+      className="scroll-mt-28 pt-28 w-[1440px] h-[600px] relative overflow-hidden"
+    >
       {/* Image de fond (optionnel) */}
       <video
         autoPlay

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,10 @@
 // src/components/Contact.tsx
 export default function Contact() {
   return (
-    <section id="contact" className="scroll-mt-28 w-full h-auto md:h-[700px] flex flex-col md:flex-row overflow-hidden">
+    <section
+      id="contact"
+      className="scroll-mt-28 pt-28 w-full h-auto md:h-[700px] flex flex-col md:flex-row overflow-hidden"
+    >
       {/* Colonne gauche : Infos */}
       <div className="w-full md:w-1/2 bg-white px-8 py-12 border-r border-zinc-300">
         <div className="mb-16">

--- a/src/components/Devices.tsx
+++ b/src/components/Devices.tsx
@@ -1,7 +1,10 @@
 // src/components/Devices.tsx
 export default function Devices() {
   return (
-    <section id="devices" className="scroll-mt-28 relative w-full h-[1500px] overflow-hidden">
+    <section
+      id="devices"
+      className="scroll-mt-28 pt-28 relative w-full h-[1500px] overflow-hidden"
+    >
       {/* Image de fond */}
       <img
         src="photos/device_mockup_fianle.png" // remplace par ton image réelle

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,10 @@
 // src/components/Hero.tsx
 export default function Hero() {
   return (
-    <section id="accueil" className="scroll-mt-28 relative w-full h-screen max-h-[810px] overflow-hidden">
+    <section
+      id="accueil"
+      className="scroll-mt-28 pt-28 relative w-full h-screen max-h-[810px] overflow-hidden"
+    >
       {/* Image de fond */}
       <video
         autoPlay


### PR DESCRIPTION
## Summary
- ensure scroll offset works for all sections
- give `Hero`, `Devices`, `About` and `Contact` top padding
- add global rule for `scroll-margin-top`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68742cf5fd588331a1a6d4ff38133fc3